### PR TITLE
Try evaluating result strictly

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -15,7 +15,7 @@ hardIO space time = do
     timer <- spin time
     arrTotal <- sum <$> mapM (readArray arr) [1..space]
     random <- fst . next <$> newStdGen
-    return $ arrTotal + random
+    return $! arrTotal + random
 
 -- A grace de cirdec at stackoverflow.
 spin :: Real a => a -> IO ()


### PR DESCRIPTION
The result you are returning is lazy, so you have to keep in mind when the value is being evaluated, in your case the IO isnt happening/completing until the result is being printed out, forcing it earlier will free up your resources earlier, i havent profiled it, but profiling usually indicates the optimal place to put the strict calls if they are required, there might be a better spot to put it.

Takes a while to get the hang of lazy evaluation by default, but its pretty natural and more flexible than strict by default once you do.